### PR TITLE
Use GNUInstallDirs properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,5 +40,5 @@ include_directories(SYSTEM
 
 set_target_properties(linux-pipewire-audio PROPERTIES PREFIX "")
 
-install(TARGETS linux-pipewire-audio LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/obs-plugins)
-install(DIRECTORY data/locale DESTINATION ${CMAKE_INSTALL_PREFIX}/share/obs/obs-plugins/linux-pipewire-audio)
+install(TARGETS linux-pipewire-audio LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/obs-plugins)
+install(DIRECTORY data/locale DESTINATION ${CMAKE_INSTALL_DATADIR}/obs/obs-plugins/linux-pipewire-audio)


### PR DESCRIPTION
CMAKE_INSTALL_<dir>

In particular, there is no need to make paths absolute by prepending CMAKE_INSTALL_PREFIX; this prefix is used by default if the DESTINATION is a relative path.

Reference: https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html